### PR TITLE
Fixed a crash triggered when a quest is missing from the lookup table

### DIFF
--- a/Questie/Modules/QuestieQuest.lua
+++ b/Questie/Modules/QuestieQuest.lua
@@ -728,6 +728,9 @@ function Questie:getQuestHash(name, level, objectiveText)
 		end
 	end
 	
+	print("Quest not found: " .. name);
+	QuestieQuestHashCache[name..hashLevel..hashText] = 0;
+	return 0,hasOthers;
 end
 ---------------------------------------------------------------------------------------------------
 -- Checks to see if a quest is finished by quest hash


### PR DESCRIPTION
Quests which are not found in the lookup table currently crash the addon and generate a large number of Lua errors.

This commit handles the errors and prints a message to the console to notify the player of the missing quest.